### PR TITLE
IDBPR-2554 Add whereMoreLikeThis and addFunctionScore v7

### DIFF
--- a/src/Concerns/DecoratesBoolQuery.php
+++ b/src/Concerns/DecoratesBoolQuery.php
@@ -3,7 +3,12 @@
 namespace Ensi\LaravelElasticQuery\Concerns;
 
 use Closure;
+use Ensi\LaravelElasticQuery\Contracts\DSLAware;
+use Ensi\LaravelElasticQuery\Contracts\FunctionScoreItem;
+use Ensi\LaravelElasticQuery\Contracts\FunctionScoreOptions;
 use Ensi\LaravelElasticQuery\Contracts\MatchOptions;
+use Ensi\LaravelElasticQuery\Contracts\MoreLikeOptions;
+use Ensi\LaravelElasticQuery\Contracts\MoreLikeThis;
 use Ensi\LaravelElasticQuery\Contracts\MultiMatchOptions;
 use Ensi\LaravelElasticQuery\Contracts\WildcardOptions;
 use Ensi\LaravelElasticQuery\Filtering\BoolQueryBuilder;
@@ -136,6 +141,25 @@ trait DecoratesBoolQuery
     }
 
     public function addMustBool(callable $fn): static
+    {
+        $this->forwardCallTo($this->boolQuery(), __FUNCTION__, func_get_args());
+
+        return $this;
+    }
+
+    public function whereMoreLikeThis(array $fields, MoreLikeThis $likeThis, ?MoreLikeOptions $options = null): static
+    {
+        $this->forwardCallTo($this->boolQuery(), __FUNCTION__, func_get_args());
+
+        return $this;
+    }
+
+    /**
+     * @param array<FunctionScoreItem> $functions
+     * @param ?DSLAware $query
+     * @param ?FunctionScoreOptions $options
+     */
+    public function addFunctionScore(array $functions, ?DSLAware $query = null, ?FunctionScoreOptions $options = null): static
     {
         $this->forwardCallTo($this->boolQuery(), __FUNCTION__, func_get_args());
 

--- a/src/Contracts/BoolQuery.php
+++ b/src/Contracts/BoolQuery.php
@@ -42,4 +42,13 @@ interface BoolQuery
     public function orWhereWildcard(string $field, string $query, ?WildcardOptions $options = null): static;
 
     public function addMustBool(callable $fn): static;
+
+    public function whereMoreLikeThis(array $fields, MoreLikeThis $likeThis, ?MoreLikeOptions $options = null): static;
+
+    /**
+     * @param array<FunctionScoreItem> $functions
+     * @param ?DSLAware $query
+     * @param ?FunctionScoreOptions $options
+     */
+    public function addFunctionScore(array $functions, ?DSLAware $query = null, ?FunctionScoreOptions $options = null): static;
 }

--- a/src/Contracts/BoostMode.php
+++ b/src/Contracts/BoostMode.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Ensi\LaravelElasticQuery\Contracts;
+
+class BoostMode
+{
+    public const MULTIPLY = 'multiply';
+    public const REPLACE = 'replace';
+    public const SUM = 'sum';
+    public const AVG = 'avg';
+    public const MAX = 'max';
+    public const MIN = 'min';
+
+    public static function cases(): array
+    {
+        return [
+            self::MULTIPLY,
+            self::SUM,
+            self::AVG,
+            self::REPLACE,
+            self::MAX,
+            self::MIN,
+        ];
+    }
+}

--- a/src/Contracts/FunctionScoreItem.php
+++ b/src/Contracts/FunctionScoreItem.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Ensi\LaravelElasticQuery\Contracts;
+
+use Illuminate\Contracts\Support\Arrayable;
+
+class FunctionScoreItem implements Arrayable
+{
+    public function __construct(
+        private int $weight,
+        private Criteria $filter,
+    ) {
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'weight' => $this->weight,
+            'filter' => $this->filter->toDSL(),
+        ];
+    }
+}

--- a/src/Contracts/FunctionScoreOptions.php
+++ b/src/Contracts/FunctionScoreOptions.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Ensi\LaravelElasticQuery\Contracts;
+
+use Illuminate\Contracts\Support\Arrayable;
+use Webmozart\Assert\Assert;
+
+class FunctionScoreOptions implements Arrayable
+{
+    public function __construct(private array $options = [])
+    {
+    }
+
+    public static function make(
+        ?string $scoreMode = null,
+        ?string $boostMode = null,
+    ): static {
+        Assert::nullOrOneOf($scoreMode, ScoreMode::cases());
+        Assert::nullOrOneOf($boostMode, BoostMode::cases());
+
+        return new static(array_filter([
+            'score_mode' => $scoreMode,
+            'boost_mode' => $boostMode,
+        ]));
+    }
+
+    public function toArray(): array
+    {
+        return $this->options;
+    }
+}

--- a/src/Contracts/MoreLikeOptions.php
+++ b/src/Contracts/MoreLikeOptions.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Ensi\LaravelElasticQuery\Contracts;
+
+use Illuminate\Contracts\Support\Arrayable;
+
+class MoreLikeOptions implements Arrayable
+{
+    public function __construct(private array $options = [])
+    {
+    }
+
+    public static function make(
+        ?int $maxQueryTerms = null,
+        ?int $minTermFreq = null,
+        ?int $minDocFreq = null,
+        ?int $maxDocFreq = null,
+        ?int $minWordLength = null,
+        ?int $maxWordLength = null,
+        ?array $stopWords = null,
+        ?string $analyzer = null,
+        ?string $minimumShouldMatch = null,
+    ): static {
+
+        return new static(array_filter([
+            'max_query_terms' => $maxQueryTerms,
+            'min_term_freq' => $minTermFreq,
+            'min_doc_freq' => $minDocFreq,
+            'max_doc_freq' => $maxDocFreq,
+            'min_word_length' => $minWordLength,
+            'max_word_length' => $maxWordLength,
+            'stop_words' => $stopWords,
+            'analyzer' => $analyzer,
+            'minimum_should_match' => $minimumShouldMatch,
+        ]));
+    }
+
+    public function toArray(): array
+    {
+        return $this->options;
+    }
+}

--- a/src/Contracts/MoreLikeThis.php
+++ b/src/Contracts/MoreLikeThis.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Ensi\LaravelElasticQuery\Contracts;
+
+use Illuminate\Contracts\Support\Arrayable;
+
+class MoreLikeThis implements Arrayable
+{
+    private array $this = [];
+
+    public function addId(string $id, ?string $index = null): static
+    {
+        $this->this[] = array_filter([
+            '_id' => $id,
+            '_index' => $index,
+        ]);
+
+        return $this;
+    }
+
+    public function addString(string $token): static
+    {
+        $this->this[] = $token;
+
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        return $this->this;
+    }
+}

--- a/src/Contracts/ScoreMode.php
+++ b/src/Contracts/ScoreMode.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Ensi\LaravelElasticQuery\Contracts;
+
+class ScoreMode
+{
+    public const MULTIPLY = 'multiply';
+    public const SUM = 'sum';
+    public const AVG = 'avg';
+    public const FIRST = 'first';
+    public const MAX = 'max';
+    public const MIN = 'min';
+
+    public static function cases(): array
+    {
+        return [
+            self::MULTIPLY,
+            self::SUM,
+            self::AVG,
+            self::FIRST,
+            self::MAX,
+            self::MIN,
+        ];
+    }
+}

--- a/src/Filtering/BoolQueryBuilder.php
+++ b/src/Filtering/BoolQueryBuilder.php
@@ -6,10 +6,17 @@ use Closure;
 use Ensi\LaravelElasticQuery\Concerns\SupportsPath;
 use Ensi\LaravelElasticQuery\Contracts\BoolQuery;
 use Ensi\LaravelElasticQuery\Contracts\Criteria;
+use Ensi\LaravelElasticQuery\Contracts\DSLAware;
+use Ensi\LaravelElasticQuery\Contracts\FunctionScoreItem;
+use Ensi\LaravelElasticQuery\Contracts\FunctionScoreOptions;
 use Ensi\LaravelElasticQuery\Contracts\MatchOptions;
+use Ensi\LaravelElasticQuery\Contracts\MoreLikeOptions;
+use Ensi\LaravelElasticQuery\Contracts\MoreLikeThis;
 use Ensi\LaravelElasticQuery\Contracts\MultiMatchOptions;
 use Ensi\LaravelElasticQuery\Contracts\WildcardOptions;
 use Ensi\LaravelElasticQuery\Filtering\Criterias\Exists;
+use Ensi\LaravelElasticQuery\Filtering\Criterias\FunctionScore;
+use Ensi\LaravelElasticQuery\Filtering\Criterias\MoreLike;
 use Ensi\LaravelElasticQuery\Filtering\Criterias\MultiMatch;
 use Ensi\LaravelElasticQuery\Filtering\Criterias\Nested;
 use Ensi\LaravelElasticQuery\Filtering\Criterias\OneMatch;
@@ -243,6 +250,25 @@ class BoolQueryBuilder implements BoolQuery, Criteria
     protected function makeWildcard(string $field, string $query, ?WildcardOptions $options = null): Wildcard
     {
         return new Wildcard($this->absolutePath($field), $query, $options ?: new WildcardOptions());
+    }
+
+    public function whereMoreLikeThis(array $fields, MoreLikeThis $likeThis, ?MoreLikeOptions $options = null): static
+    {
+        $this->must->add(new MoreLike($fields, $likeThis, $options));
+
+        return $this;
+    }
+
+    /**
+     * @param array<FunctionScoreItem> $functions
+     * @param ?DSLAware $query
+     * @param ?FunctionScoreOptions $options
+     */
+    public function addFunctionScore(array $functions, ?DSLAware $query = null, ?FunctionScoreOptions $options = null): static
+    {
+        $this->should->add(new FunctionScore($functions, $query, $options));
+
+        return $this;
     }
 
     public function addMustBool(callable $fn): static

--- a/src/Filtering/Criterias/FunctionScore.php
+++ b/src/Filtering/Criterias/FunctionScore.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Ensi\LaravelElasticQuery\Filtering\Criterias;
+
+use Ensi\LaravelElasticQuery\Contracts\Criteria;
+use Ensi\LaravelElasticQuery\Contracts\DSLAware;
+use Ensi\LaravelElasticQuery\Contracts\FunctionScoreItem;
+use Ensi\LaravelElasticQuery\Contracts\FunctionScoreOptions;
+use stdClass;
+use Webmozart\Assert\Assert;
+
+class FunctionScore implements Criteria
+{
+    /**
+     * @param array<FunctionScoreItem> $functions
+     * @param FunctionScoreOptions|null $options
+     */
+    public function __construct(
+        private array $functions,
+        private ?DSLAware $query = null,
+        private ?FunctionScoreOptions $options = null,
+    ) {
+        array_map(fn ($function) => Assert::isInstanceOfAny($function, [FunctionScoreItem::class]), $functions);
+    }
+
+    public function toDSL(): array
+    {
+        $body = [
+            'query' => $this->query?->toDSL() ?? ['match_all' => new stdClass()],
+            'functions' => array_map(fn (FunctionScoreItem $function) => $function->toArray(), $this->functions),
+        ];
+
+        if ($this->options) {
+            $body = array_merge($this->options->toArray(), $body);
+        }
+
+        return ['function_score' => $body];
+    }
+}

--- a/src/Filtering/Criterias/MoreLike.php
+++ b/src/Filtering/Criterias/MoreLike.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Ensi\LaravelElasticQuery\Filtering\Criterias;
+
+use Ensi\LaravelElasticQuery\Contracts\Criteria;
+use Ensi\LaravelElasticQuery\Contracts\MoreLikeOptions;
+use Ensi\LaravelElasticQuery\Contracts\MoreLikeThis;
+use Webmozart\Assert\Assert;
+
+class MoreLike implements Criteria
+{
+    public function __construct(
+        private array $fields,
+        private MoreLikeThis $likeThis,
+        private ?MoreLikeOptions $options = null,
+    ) {
+        Assert::minCount($fields, 1);
+        array_map(Assert::stringNotEmpty(...), $fields);
+    }
+
+    public function toDSL(): array
+    {
+        $body = [
+            'fields' => $this->fields,
+            'like' => $this->likeThis->toArray(),
+        ];
+
+        if ($this->options) {
+            $body = array_merge($this->options->toArray(), $body);
+        }
+
+        return ['more_like_this' => $body];
+    }
+}

--- a/tests/IntegrationTests/Search/SearchQueryIntegrationTest.php
+++ b/tests/IntegrationTests/Search/SearchQueryIntegrationTest.php
@@ -1,14 +1,23 @@
 <?php
 
 use Ensi\LaravelElasticQuery\Contracts\BoolQuery;
+use Ensi\LaravelElasticQuery\Contracts\BoostMode;
+use Ensi\LaravelElasticQuery\Contracts\FunctionScoreItem;
+use Ensi\LaravelElasticQuery\Contracts\FunctionScoreOptions;
+use Ensi\LaravelElasticQuery\Contracts\MoreLikeOptions;
+use Ensi\LaravelElasticQuery\Contracts\MoreLikeThis;
+use Ensi\LaravelElasticQuery\Contracts\ScoreMode;
 use Ensi\LaravelElasticQuery\Contracts\SortableQuery;
+use Ensi\LaravelElasticQuery\Filtering\Criterias\Terms;
 use Ensi\LaravelElasticQuery\Tests\Data\Models\ProductsIndex;
 use Ensi\LaravelElasticQuery\Tests\IntegrationTestCase;
 use Ensi\LaravelElasticQuery\Tests\IntegrationTests\Search\TestCases\SearchIntegrationTestCase;
 
 use function PHPUnit\Framework\assertArrayNotHasKey;
+use function PHPUnit\Framework\assertContains;
 use function PHPUnit\Framework\assertCount;
 use function PHPUnit\Framework\assertEquals;
+use function PHPUnit\Framework\assertEqualsCanonicalizing;
 
 uses(SearchIntegrationTestCase::class);
 
@@ -110,4 +119,54 @@ test('search query collapse', function () {
     $result = ProductsIndex::query()->collapse('vat')->get();
 
     assertCount(2, $result);
+});
+
+test('search query more like this', function (array $fields, MoreLikeThis $likeThis, array $expectedIds) {
+    /** @var SearchIntegrationTestCase $this */
+
+    $result = ProductsIndex::query()
+        ->whereMoreLikeThis(
+            $fields,
+            $likeThis,
+            options: MoreLikeOptions::make(
+                minTermFreq: 1,
+                minDocFreq: 1,
+            )
+        )
+        ->get();
+
+    assertEqualsCanonicalizing($expectedIds, $result->pluck('_id')->all());
+})->with([
+    'array id' => [['tags'], (new MoreLikeThis())->addId('405'), ['150']],
+    'array string' => [['tags'], (new MoreLikeThis())->addString('drinks'), ['150', '405']],
+    'full text id' => [['description'], (new MoreLikeThis())->addId('1'), ['150', '328', '471']],
+    'full text string' => [['description'], (new MoreLikeThis())->addString('description'), ['1', '150', '471']],
+    'full text combine' => [['description'], (new MoreLikeThis())->addId('1')->addString('water'), ['150', '328', '405', '471']],
+]);
+
+test('search query add function score', function () {
+    /** @var SearchIntegrationTestCase $this */
+
+    $result = ProductsIndex::query()
+        ->addFunctionScore(
+            [
+                new FunctionScoreItem(
+                    weight: 10,
+                    filter: new Terms(
+                        field: "tags",
+                        values: ["drinks"],
+                    ),
+                ),
+            ],
+            options: FunctionScoreOptions::make(
+                scoreMode: ScoreMode::SUM,
+                boostMode: BoostMode::SUM
+            )
+        )
+        ->get();
+
+    assertCount(6, $result);
+
+    assertContains('drinks', $result[0]['_source']['tags']);
+    assertContains('drinks', $result[1]['_source']['tags']);
 });


### PR DESCRIPTION
Задача: поиск подобных товаров с возможность приоритизации по схожим параметрам.

Добавлена механика: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-mlt-query.html
для поиска подобных товаров по определенным полям.

Добавлена механика: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html
для приоритезации товара по совпадающим полям.

Данные механики позволяют реализовать необходимый кейс:
```
       $query = new SearchQuery($index);

        $query->whereMoreLikeThis(
            ['name'],
            (new MoreLikeThis())->addId($data->baseProduct->id),
            MoreLikeOptions::make(
                minTermFreq: 1,
                maxQueryTerms: 12,
                minimumShouldMatch: '80%'
            ),
        );

        $functions = [];
        foreach ($data->priorityFactor->items as $item) {
            $functions[] = new FunctionScoreItem(
                weight: $item->weight,
                filter: new Terms(
                    field: $item->field->value,
                    values: $data->baseProduct->getValue($item->field->value),
                ),
            );
        }
        $query->addFunctionScore($functions, options: FunctionScoreOptions::make(
            scoreMode: ScoreMode::SUM,
            boostMode: BoostMode::SUM
        ));

        return $query->paginate($data->limitProducts);
```